### PR TITLE
Show last update timestamp on page

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,12 +7,19 @@ let mapping = {};                           // filled on load
 const form   = document.getElementById('lookupForm');
 const input  = document.getElementById('appealInput');
 const result = document.getElementById('result');
+const updatedEl = document.getElementById('updated');
 
 // ---------- 1. Fetch mapping.json --------------------------------------
 fetch('mapping.json')
   .then(r => r.json())
   .then(data => { mapping = data; })
   .catch(() => showError('Tókst ekki að hlaða gögnunum :('));
+
+// ---------- 1b. Fetch last-updated timestamp ---------------------------
+fetch('last_updated.txt')
+  .then(r => r.text())
+  .then(text => { updatedEl.innerHTML = text; })
+  .catch(() => { updatedEl.textContent = 'Síðast uppfært óþekkt.'; });
 
 // ---------- 2. Lookup on form submit -----------------------------------
 form.addEventListener('submit', evt => {

--- a/get_new_verdicts.py
+++ b/get_new_verdicts.py
@@ -6,6 +6,8 @@ import pandas as pd
 from pathlib import Path
 from bs4 import BeautifulSoup
 from urllib.parse import urlparse, urljoin
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 HEADERS = {"User-Agent": ( "Mozilla/5.0 (X11; Linux x86_64) ")}
 
@@ -172,6 +174,27 @@ def main():
         for v in mapping.values()
     )
     print(f"Wrote {json_file} with {total:,} verdict links")
+
+    # 5) Write timestamp in Icelandic locale format
+    months = [
+        "",
+        "janúar",
+        "febrúar",
+        "mars",
+        "apríl",
+        "maí",
+        "júní",
+        "júlí",
+        "ágúst",
+        "september",
+        "október",
+        "nóvember",
+        "desember",
+    ]
+    dt = datetime.now(ZoneInfo("Atlantic/Reykjavik"))
+    ts_str = f"Síðast uppfært {dt.day}. {months[dt.month]} {dt.year}."
+    Path("last_updated.txt").write_text(ts_str, encoding="utf-8")
+    print(f"Wrote last_updated.txt: {ts_str}")
 
 if __name__ == "__main__":
     main()

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 <body>
   <h1>Finna dóma og ákvarðanir Hæstaréttar</h1>
 
-  <p class="updated">Síðast uppfært&nbsp;7.&nbsp;júlí&nbsp;2025.</p>   <!-- NEW -->
+  <p id="updated" class="updated"></p>   <!-- NEW -->
 
   <form id="lookupForm">
     <label>

--- a/last_updated.txt
+++ b/last_updated.txt
@@ -1,0 +1,1 @@
+Síðast uppfært 7. júlí 2025.


### PR DESCRIPTION
## Summary
- output timestamp from script in Icelandic
- load timestamp dynamically on the webpage
- placeholder update element in the HTML

## Testing
- `python3 -m py_compile get_new_verdicts.py`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_687426858308832184f34c824ca0da80